### PR TITLE
Add error handling to ol.featureloader.xhr

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -3,6 +3,7 @@ goog.provide('ol.featureloader');
 goog.require('ol');
 goog.require('ol.format.FormatType');
 goog.require('ol.xml');
+goog.require('ol.source.State');
 
 
 /**
@@ -64,6 +65,9 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
             failure.call(this);
           }
         }.bind(this);
+        xhr.onerror = function(event) {
+            failure.call(this);
+        }.bind(this);
         xhr.send();
       });
 };
@@ -87,5 +91,7 @@ ol.featureloader.xhr = function(url, format) {
        */
       function(features, dataProjection) {
         this.addFeatures(features);
-      }, /* FIXME handle error */ ol.nullFunction);
+      }, function () {
+        this.setState(ol.source.State.ERROR);
+      });
 };


### PR DESCRIPTION
Added an onerror handler to the XHR calls on ol.featureloader.loadFeaturesXhr and an event handler function that sets the error state for the source.